### PR TITLE
feat: 조회 조건을 인터페이스와 메서드 참조로 분리

### DIFF
--- a/src/main/java/org/example/functional/FunctionSearchingTravel.java
+++ b/src/main/java/org/example/functional/FunctionSearchingTravel.java
@@ -1,0 +1,7 @@
+package org.example.functional;
+
+public class FunctionSearchingTravel {
+    public static boolean isVietname(TravelInfo travelInfo){
+        return travelInfo.getCountry().equals("vietnam");
+    }
+}

--- a/src/main/java/org/example/functional/Main.java
+++ b/src/main/java/org/example/functional/Main.java
@@ -1,0 +1,38 @@
+package org.example.functional;
+
+import java.util.List;
+
+public class Main {
+    public static void main(String[] args) {
+        NewSearchingTravel travelSearch = new NewSearchingTravel();
+
+        List<TravelInfo> searchTravel = travelSearch.searchTravelInfo(new TravelInfoFilter() {
+            @Override
+            public boolean isMatched(TravelInfo travelInfo) {
+                if (travelInfo.getCountry().equals("vietnam")) {
+                    return true;
+                } else {
+                    return false;
+                }
+            }
+        });
+
+        for(TravelInfo travelInfo: searchTravel){
+            System.out.println(travelInfo);
+        }
+
+        // 람다 표현식으로 변환
+        List<TravelInfo> searchTravelWithCity = travelSearch.searchTravelInfo(travelInfo -> travelInfo.getCountry().equals("hanoi"));
+
+        for(TravelInfo travelInfo: searchTravelWithCity){
+            System.out.println(travelInfo);
+        }
+
+        // 조건식을 메서드 참조 형태로 변경
+        List<TravelInfo> travelInfos = travelSearch.searchTravelInfo(FunctionSearchingTravel::isVietname);
+        for(TravelInfo travelInfo: travelInfos){
+            System.out.println(travelInfo);
+        }
+    }
+
+}

--- a/src/main/java/org/example/functional/NewSearchingTravel.java
+++ b/src/main/java/org/example/functional/NewSearchingTravel.java
@@ -1,0 +1,22 @@
+package org.example.functional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class NewSearchingTravel {
+    private List<TravelInfo> travelInfoList = new ArrayList<>();
+
+    // 외부에서 전달된 조건으로 검색
+    public List<TravelInfo> searchTravelInfo(TravelInfoFilter searchCondition) {
+        List<TravelInfo> resultValue = new ArrayList<>();
+
+        for(TravelInfo info : travelInfoList){
+            if(searchCondition.isMatched(info)){
+                resultValue.add(info);
+            }
+        }
+
+        return resultValue;
+    }
+
+}

--- a/src/main/java/org/example/functional/TravelInfo.java
+++ b/src/main/java/org/example/functional/TravelInfo.java
@@ -1,0 +1,57 @@
+package org.example.functional;
+
+public class TravelInfo {
+    private String name;
+    private String country;
+    private String city;
+    private int days;
+    private int nights;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getCountry() {
+        return country;
+    }
+
+    public void setCountry(String country) {
+        this.country = country;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public void setCity(String city) {
+        this.city = city;
+    }
+
+    public int getDays() {
+        return days;
+    }
+
+    public void setDays(int days) {
+        this.days = days;
+    }
+
+    public int getNights() {
+        return nights;
+    }
+
+    public void setNights(int nights) {
+        this.nights = nights;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append(name).append(" : ").append(country).append(",").append(city)
+                .append(", ").append(nights).append("박").append(days).append("일");
+        return builder.toString();
+    }
+}

--- a/src/main/java/org/example/functional/TravelInfoFilter.java
+++ b/src/main/java/org/example/functional/TravelInfoFilter.java
@@ -1,0 +1,5 @@
+package org.example.functional;
+
+public interface TravelInfoFilter {
+    public boolean isMatched(TravelInfo travelInfo);
+}


### PR DESCRIPTION
- `TravelInfo`class 조회 대상 클래스 정의
- `TravelInfoFilter` interface
  - 검색 메서드 `isMatched()`를 인터페이스로 노출, 실행결과는 별도로 분리
  - 여행 상품을 관리하는 클래스와 상품을 조회하는 로직을 분리
- `NewSearchingTravel`class 조회 서비스 정의
  - `searchTravelInfo(TravelInfoFilter)`조회 조건 인터페이스를 받아 조건에 따른 로직 처리
  - 여행 상품 관리
- `FunctionSearchingTravel` interface
  - 메서드 참조를 위한 인터페이스
  - 람다 표현식을 하나의 함수로 선언하고 다른 곳에서 재사용

Closes #3